### PR TITLE
feat: Add tunnel support

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -44,7 +44,7 @@ class App extends React.Component {
 
     // fetch tunnel info every 20 seconds
     setInterval(async () => {
-      const tunnels = await this.getTunnels(credential, username, region)
+      const tunnels = await this.getTunnels(credential, username, region);
       this.setState({availableTunnels: tunnels});
     }, 20000);
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -42,9 +42,11 @@ class App extends React.Component {
       credential,
     } = await this.getAccountSetting();
 
-    const tunnels = await this.getTunnels(credential, username, region)
-
-    this.setState({availableTunnels: tunnels});
+    // fetch tunnel info every 20 seconds
+    setInterval(async () => {
+      const tunnels = await this.getTunnels(credential, username, region)
+      this.setState({availableTunnels: tunnels});
+    }, 20000);
   }
 
   async componentDidUpdate() {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -115,7 +115,7 @@ class App extends React.Component {
       jobId: jobId,
       platform: '',
       region: region
-    })
+    });
   }
 
   async getAccountSetting() {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,13 +34,13 @@ class App extends React.Component {
 
   async componentDidMount() {
     const token = await this.readStorage('token');
-    this.setState({token: token})
+    this.setState({token: token});
 
     const {
       username,
       region,
       credential,
-    } = await this.getAccountSetting()
+    } = await this.getAccountSetting();
 
     const tunnels = await this.getTunnels(credential, username, region)
 
@@ -56,7 +56,7 @@ class App extends React.Component {
     const {
       region,
       credential,
-    } = await this.getAccountSetting()
+    } = await this.getAccountSetting();
 
     const recording = await this.readStorage('recording');
     this.setState({suite: JSON.parse(recording).title});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -149,7 +149,7 @@ class App extends React.Component {
     const tunnelIdentifiers = [];
     Object.values(body).forEach(tunnels => {
       tunnels.forEach(item => 
-        tunnelIdentifiers.push(item.tunnel_identifier)
+        tunnelIdentifiers.push(item.tunnel_identifier);
       )
     })
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -123,7 +123,7 @@ class App extends React.Component {
     const accessKey = await this.readStorage('accessKey');
     const region = await this.readStorage('region') || 'us-west-1';
     const credential = window.btoa(`${username}:${accessKey}`);
-    return { username, accessKey, region, credential }
+    return { username, accessKey, region, credential };
   }
 
   async getTunnels(credential, username, region) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,7 +127,7 @@ class App extends React.Component {
   }
 
   async getTunnels(credential, username, region) {
-    const url = `https://api.${region}.saucelabs.com/rest/v1/${username}/tunnels?full=true&all=true`
+    const url = `https://api.${region}.saucelabs.com/rest/v1/${username}/tunnels?full=true&all=true`;
     let resp;
     try {
       resp = await fetch(url, {

--- a/src/ConfigForm.css
+++ b/src/ConfigForm.css
@@ -16,7 +16,7 @@
   margin-right: 0;
 }
 
-.platform {
+select {
   display: flex;
   min-width: 150px;
   margin-left: auto;

--- a/src/ConfigForm.jsx
+++ b/src/ConfigForm.jsx
@@ -20,8 +20,6 @@ class ConfigForm extends React.Component {
       tunnels,
     } = this.props;
 
-    console.log('tunnels: ', tunnels)
-
       return (
         <div className="form">
           <form onSubmit={(event) => handleConfig(event, this.state)}>

--- a/src/ConfigForm.jsx
+++ b/src/ConfigForm.jsx
@@ -6,21 +6,37 @@ class ConfigForm extends React.Component {
     super(props);
     this.state = {
       platform: 'Windows 11',
+      tunnelName: '',
     }
   }
 
   handleChange(key, event) {
-    this.setState({[key]: event.target.value,});
+    this.setState({[key]: event.target.value});
   }
 
   render() {
     const {
-      handleConfig
+      handleConfig,
+      tunnels,
     } = this.props;
 
       return (
         <div className="form">
           <form onSubmit={(event) => handleConfig(event, this.state)}>
+            { tunnels.length > 0 && (
+              <div className="form-row">
+                <label className="form-label">
+                  Tunnel Name
+                </label>
+                <select className="tunnel" id="tunnel" value={this.state.tunnelName} onChange={(event) => this.handleChange('tunnelName', event)}>
+                  <option value="not set">Not Set</option>
+                  { tunnels.map((tunnel) => (
+                      <option value={tunnel}>{tunnel}</option>
+                    ))
+                  }
+                </select>
+              </div>
+            )}
             <div className="form-row">
               <label className="form-label">
                 Platform

--- a/src/ConfigForm.jsx
+++ b/src/ConfigForm.jsx
@@ -6,7 +6,7 @@ class ConfigForm extends React.Component {
     super(props);
     this.state = {
       platform: 'Windows 11',
-      tunnelName: '',
+      tunnel: '',
     }
   }
 
@@ -20,15 +20,17 @@ class ConfigForm extends React.Component {
       tunnels,
     } = this.props;
 
+    console.log('tunnels: ', tunnels)
+
       return (
         <div className="form">
           <form onSubmit={(event) => handleConfig(event, this.state)}>
             { tunnels.length > 0 && (
               <div className="form-row">
                 <label className="form-label">
-                  Tunnel Name
+                  Tunnel
                 </label>
-                <select className="tunnel" id="tunnel" value={this.state.tunnelName} onChange={(event) => this.handleChange('tunnelName', event)}>
+                <select className="tunnel" id="tunnel" value={this.state.tunnel} onChange={(event) => this.handleChange('tunnel', event)}>
                   <option value="not set">Not Set</option>
                   { tunnels.map((tunnel) => (
                       <option value={tunnel}>{tunnel}</option>


### PR DESCRIPTION
User can select tunnel from the extension and pass it to sauce.

With available tunnels: https://app.saucelabs.com/tests/94a16dff1aa24d3bb811f6beb9c85b68
<img width="314" alt="Screenshot 2023-06-28 at 2 08 24 PM" src="https://github.com/saucelabs/replay-chrome-extension/assets/71669683/ccb33c1b-3337-4d3f-a1f5-570ecefa1a81">

Without available tunnel:
<img width="314" alt="Screenshot 2023-06-28 at 2 08 54 PM" src="https://github.com/saucelabs/replay-chrome-extension/assets/71669683/ff7803a3-1446-42eb-ab78-315ff55b185d">
